### PR TITLE
Add short options for aims command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ informative markers. The command expects the `structure` program to be
 available in the environment.
 
 ```bash
-wasptk aims sample.vcf --bam sample.bam -s SAMPLE_ID -o result.json
+wasptk aims -v sample.vcf -b sample.bam -s SAMPLE_ID -o result.json
 ```
 
 The input VCF may be plain text, gzipped (`.vcf.gz`) or BCF.
 
 The output is a JSON document reporting the inferred ancestry, probabilities
 for each ancestry and how many AIMs were present in the input VCF. Use
-`--bam` to provide the alignment file used for coverage calculation, `-s/--sample`
-to specify a sample identifier and `-o/--output` to write the JSON to a file.
+`-b/--bam` to provide the alignment file used for coverage calculation,
+`-v/--vcf` to specify the AIM variant file, `-s/--sample` to set a sample
+identifier and `-o/--output` to write the JSON to a file.

--- a/wasptk/cli.py
+++ b/wasptk/cli.py
@@ -59,8 +59,17 @@ def main() -> None:
     p_plot.set_defaults(func=_cmd_plotcov)
 
     p_aims = sub.add_parser("aims", help="Infer ancestry using AIMs")
-    p_aims.add_argument("vcf", help="Input VCF with AIM variants")
-    p_aims.add_argument("--bam", help="BAM file for coverage calculation")
+    p_aims.add_argument(
+        "-v",
+        "--vcf",
+        required=True,
+        help="Input VCF with AIM variants",
+    )
+    p_aims.add_argument(
+        "-b",
+        "--bam",
+        help="BAM file for coverage calculation",
+    )
     p_aims.add_argument(
         "-s",
         "--sample",


### PR DESCRIPTION
## Summary
- allow specifying input VCF with `-v/--vcf`
- add `-b/--bam` short option
- update README usage example and option descriptions

## Testing
- `python -m py_compile wasptk/cli.py wasptk/ancestry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d5059990832a81e23b928605d1e8